### PR TITLE
Carousel colors

### DIFF
--- a/TruckMuncher/Base.lproj/LaunchScreen.xib
+++ b/TruckMuncher/Base.lproj/LaunchScreen.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
@@ -27,7 +27,7 @@
                     </constraints>
                 </imageView>
             </subviews>
-            <color key="backgroundColor" red="0.60392156862745094" green="0.0" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.9137254901960784" green="0.11764705882352941" blue="0.38823529411764707" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="FPE-e8-qi3" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="HJ0-2C-LCe"/>
                 <constraint firstItem="8ie-xW-0ye" firstAttribute="centerX" secondItem="FPE-e8-qi3" secondAttribute="centerX" id="L0s-TN-9KW"/>

--- a/TruckMuncher/Colors.swift
+++ b/TruckMuncher/Colors.swift
@@ -11,3 +11,4 @@ import UIKit
 
 let pinkColor = UIColor(rgba: "#E91E63")
 let wetAsphaltColor = UIColor(rgba: "#34495E")
+let clouds = UIColor(red: 236.0/255.0, green: 240.0/255.0, blue: 241.0/255.0, alpha: 1.0)

--- a/TruckMuncher/Colors.swift
+++ b/TruckMuncher/Colors.swift
@@ -11,4 +11,4 @@ import UIKit
 
 let pinkColor = UIColor(rgba: "#E91E63")
 let wetAsphaltColor = UIColor(rgba: "#34495E")
-let clouds = UIColor(red: 236.0/255.0, green: 240.0/255.0, blue: 241.0/255.0, alpha: 1.0)
+let carouselBackground = UIColor.whiteColor()

--- a/TruckMuncher/Helpers/UIColor+Hex.swift
+++ b/TruckMuncher/Helpers/UIColor+Hex.swift
@@ -52,4 +52,18 @@ extension UIColor {
         var bgDelta = ((red*255.0*0.299) + (green*255.0*0.587) + (blue*255.0*0.114))
         return (255.0-bgDelta < threshold) ? UIColor.blackColor() : UIColor.whiteColor()
     }
+    
+    func transformToColor(destinationColor: UIColor, withPercentage percentage: CGFloat) -> UIColor {
+        var baseRed: CGFloat = 0, baseGreen: CGFloat = 0, baseBlue: CGFloat = 0, baseAlpha: CGFloat = 0
+        getRed(&baseRed, green: &baseGreen, blue: &baseBlue, alpha: &baseAlpha)
+        
+        var destinationRed: CGFloat = 0, destinationGreen: CGFloat = 0, destinationBlue: CGFloat = 0, destinationAlpha: CGFloat = 0
+        destinationColor.getRed(&destinationRed, green: &destinationGreen, blue: &destinationBlue, alpha: &destinationAlpha)
+        
+        let red = baseRed + (destinationRed - baseRed)*percentage
+        let blue = baseBlue + (destinationBlue - baseBlue)*percentage
+        let green = baseGreen + (destinationGreen - baseGreen)*percentage
+        let alpha = baseAlpha + (destinationAlpha - baseAlpha)*percentage
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
 }

--- a/TruckMuncher/MapViewController.swift
+++ b/TruckMuncher/MapViewController.swift
@@ -324,6 +324,11 @@ class MapViewController: UIViewController,
         navbarFrame.origin.y = min(max(top - percentage*navbarFrame.size.height, top - navbarFrame.size.height), top)
         navigationController?.navigationBar.frame = navbarFrame
         
+        let primaryColor = UIColor(rgba: (activeTrucks[truckCarousel.currentItemIndex] as RTruck).primaryColor)
+        let currentView = truckCarousel.itemViewAtIndex(truckCarousel.currentItemIndex) as TruckDetailView
+        currentView.updateViewWithColor(clouds.transformToColor(primaryColor, withPercentage: percentage))
+        //currentView.backgroundColor = clouds.transformToColor(primaryColor, withPercentage: percentage)
+        
         if recognizer.state == .Ended {
             // if we ended the pan, based on the velocity, we need to snap the menu and nav bar to their final positions as well as fading nav bar items
             let velocity = recognizer.velocityInView(view)
@@ -337,6 +342,8 @@ class MapViewController: UIViewController,
                 self.navigationItem.titleView?.alpha = self.showingMenu ? 0.0 : 1.0
                 self.navigationItem.leftBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
                 self.navigationItem.rightBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
+            }, completion: { (completed) -> Void in
+                currentView.updateViewWithColor(self.showingMenu ? primaryColor : clouds)
             })
             initialTouchY = 0
         }
@@ -354,7 +361,7 @@ class MapViewController: UIViewController,
             view = viewArray[0] as TruckDetailView
             view.frame = CGRectMake(0.0, 0.0, truckCarousel.frame.size.width, truckCarousel.frame.size.height)
         }
-        (view as TruckDetailView).updateViewWithTruck(activeTrucks[index])
+        (view as TruckDetailView).updateViewWithTruck(activeTrucks[index], showingMenu: showingMenu)
 
         return view
     }

--- a/TruckMuncher/MapViewController.swift
+++ b/TruckMuncher/MapViewController.swift
@@ -31,7 +31,11 @@ class MapViewController: UIViewController,
     var count: Int = 0
     var showingMenu = false
     var originalTrucks = [RTruck]()
-    var activeTrucks = [RTruck]()
+    var activeTrucks: [RTruck] = [RTruck]() {
+        didSet {
+            self.truckCarousel.layer.shadowOpacity = self.activeTrucks.count > 0 ? 0.2 : 0.0
+        }
+    }
     
     let trucksManager = TrucksManager()
     let menuManager = MenuManager()
@@ -90,6 +94,11 @@ class MapViewController: UIViewController,
         truckCarousel.pagingEnabled = true
         truckCarousel.currentItemIndex = 0
         truckCarousel.bounces = true
+        truckCarousel.layer.masksToBounds = false
+        truckCarousel.layer.shadowColor = UIColor.blackColor().CGColor
+        truckCarousel.layer.shadowOffset = CGSizeMake(0.0, -3.0)
+        truckCarousel.layer.shadowOpacity = 0.0
+        truckCarousel.layer.shadowPath = UIBezierPath(rect: truckCarousel.bounds).CGPath
         
         view.addSubview(truckCarousel)
         attachGestureRecognizerToCarousel()
@@ -327,7 +336,6 @@ class MapViewController: UIViewController,
         let primaryColor = UIColor(rgba: (activeTrucks[truckCarousel.currentItemIndex] as RTruck).primaryColor)
         let currentView = truckCarousel.itemViewAtIndex(truckCarousel.currentItemIndex) as TruckDetailView
         currentView.updateViewWithColor(clouds.transformToColor(primaryColor, withPercentage: percentage))
-        //currentView.backgroundColor = clouds.transformToColor(primaryColor, withPercentage: percentage)
         
         if recognizer.state == .Ended {
             // if we ended the pan, based on the velocity, we need to snap the menu and nav bar to their final positions as well as fading nav bar items
@@ -344,6 +352,7 @@ class MapViewController: UIViewController,
                 self.navigationItem.rightBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
             }, completion: { (completed) -> Void in
                 currentView.updateViewWithColor(self.showingMenu ? primaryColor : clouds)
+                self.truckCarousel.reloadData()
             })
             initialTouchY = 0
         }

--- a/TruckMuncher/MapViewController.swift
+++ b/TruckMuncher/MapViewController.swift
@@ -335,7 +335,7 @@ class MapViewController: UIViewController,
         
         let primaryColor = UIColor(rgba: (activeTrucks[truckCarousel.currentItemIndex] as RTruck).primaryColor)
         let currentView = truckCarousel.itemViewAtIndex(truckCarousel.currentItemIndex) as TruckDetailView
-        currentView.updateViewWithColor(clouds.transformToColor(primaryColor, withPercentage: percentage))
+        currentView.updateViewWithColor(carouselBackground.transformToColor(primaryColor, withPercentage: percentage))
         
         if recognizer.state == .Ended {
             // if we ended the pan, based on the velocity, we need to snap the menu and nav bar to their final positions as well as fading nav bar items
@@ -351,7 +351,7 @@ class MapViewController: UIViewController,
                 self.navigationItem.leftBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
                 self.navigationItem.rightBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
             }, completion: { (completed) -> Void in
-                currentView.updateViewWithColor(self.showingMenu ? primaryColor : clouds)
+                currentView.updateViewWithColor(self.showingMenu ? primaryColor : carouselBackground)
                 self.truckCarousel.reloadData()
             })
             initialTouchY = 0

--- a/TruckMuncher/MapViewController.swift
+++ b/TruckMuncher/MapViewController.swift
@@ -350,8 +350,10 @@ class MapViewController: UIViewController,
                 self.navigationItem.titleView?.alpha = self.showingMenu ? 0.0 : 1.0
                 self.navigationItem.leftBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
                 self.navigationItem.rightBarButtonItem?.tintColor = color.colorWithAlphaComponent(self.showingMenu ? 0.0 : 1.0)
-            }, completion: { (completed) -> Void in
+                
                 currentView.updateViewWithColor(self.showingMenu ? primaryColor : carouselBackground)
+
+            }, completion: { (completed) -> Void in
                 self.truckCarousel.reloadData()
             })
             initialTouchY = 0

--- a/TruckMuncher/MapViewController.xib
+++ b/TruckMuncher/MapViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>

--- a/TruckMuncher/TruckDetailView.swift
+++ b/TruckMuncher/TruckDetailView.swift
@@ -40,7 +40,7 @@ class TruckDetailView: UIView, UITableViewDataSource, UITableViewDelegate {
         }
         truckTagsLabel.text = join(", ", keywords)
         
-        let primary = showingMenu ? UIColor(rgba: truck.primaryColor) : clouds
+        let primary = showingMenu ? UIColor(rgba: truck.primaryColor) : carouselBackground
         backgroundColor = primary
         textColor = primary.suggestedTextColor()
         truckNameLabel.textColor = textColor

--- a/TruckMuncher/TruckDetailView.swift
+++ b/TruckMuncher/TruckDetailView.swift
@@ -25,6 +25,8 @@ class TruckDetailView: UIView, UITableViewDataSource, UITableViewDelegate {
         menuTableView.registerNib(UINib(nibName: "MenuItemTableViewCell", bundle: NSBundle.mainBundle()), forCellReuseIdentifier: "MenuItemTableViewCellIdentifier")
         menuTableView.estimatedRowHeight = 44.0
         menuTableView.rowHeight = UITableViewAutomaticDimension
+        menuTableView.backgroundView = nil
+        menuTableView.backgroundColor = UIColor.clearColor()
     }
     
     func updateViewWithTruck(truck:RTruck!, showingMenu: Bool) {
@@ -101,7 +103,7 @@ class TruckDetailView: UIView, UITableViewDataSource, UITableViewDelegate {
         var label = UILabel(frame: CGRectMake(0, 0, menuTableView.frame.size.width, MENU_CATEGORY_HEIGHT))
         label.textAlignment = .Center
         label.font = UIFont.italicSystemFontOfSize(18.0)
-        label.backgroundColor = backgroundColor
+        label.backgroundColor = UIColor.clearColor()
         label.textColor = textColor
         label.text = self.tableView(tableView, titleForHeaderInSection: section)
         container.addSubview(label)

--- a/TruckMuncher/TruckDetailView.swift
+++ b/TruckMuncher/TruckDetailView.swift
@@ -27,7 +27,7 @@ class TruckDetailView: UIView, UITableViewDataSource, UITableViewDelegate {
         menuTableView.rowHeight = UITableViewAutomaticDimension
     }
     
-    func updateViewWithTruck(truck:RTruck!) {
+    func updateViewWithTruck(truck:RTruck!, showingMenu: Bool) {
         menu = RMenu.objectsWhere("truckId = %@", truck.id).firstObject() as? RMenu
         menuTableView.reloadData()
         
@@ -40,11 +40,19 @@ class TruckDetailView: UIView, UITableViewDataSource, UITableViewDelegate {
         }
         truckTagsLabel.text = join(", ", keywords)
         
-        let primary = UIColor(rgba: truck.primaryColor)
+        let primary = showingMenu ? UIColor(rgba: truck.primaryColor) : clouds
         backgroundColor = primary
         textColor = primary.suggestedTextColor()
         truckNameLabel.textColor = textColor
         truckTagsLabel.textColor = textColor
+    }
+    
+    func updateViewWithColor(color: UIColor) {
+        backgroundColor = color
+        textColor = color.suggestedTextColor()
+        truckNameLabel.textColor = textColor
+        truckTagsLabel.textColor = textColor
+        menuTableView.reloadData()
     }
     
     func getImageForTruck(truck:RTruck) {

--- a/TruckMuncher/TruckDetailView.xib
+++ b/TruckMuncher/TruckDetailView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
@@ -19,9 +19,9 @@
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="Os3-Sb-VHj">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="none" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="Os3-Sb-VHj">
                     <rect key="frame" x="0.0" y="102" width="414" height="634"/>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     <connections>
                         <outlet property="dataSource" destination="iN0-l3-epB" id="X8r-zU-yJW"/>
                         <outlet property="delegate" destination="iN0-l3-epB" id="bgp-ly-66R"/>

--- a/TruckMuncher/TruckDetailView.xib
+++ b/TruckMuncher/TruckDetailView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C81f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>


### PR DESCRIPTION
Carousel is white all the time, transforms to trucks color on drag. Updated the splash screen to the new pink. 

The only thing I'm kind of unsure about is if you drag the carousel up just a little bit and then let go, you'll notice that the colors dont transform to the trucks colors until the animation is finished. So you drag it a little bit, let go, the carousel flies to the top, and then the colors change. But if you drag it all the way without letting go it's smooth and looks great. There's really no progress callback for animations (as far as I know) to allow better control over this. For now I suppose its ok. It looks better than changing it before the animation starts (or during). 